### PR TITLE
Test for IP ban by site before tracker checkout

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -108,6 +108,26 @@ class CheckIP(SimpleTask):
         else:
             self._counter -= 1
 
+class CheckBan(SimpleTask):
+    def __init__(self):
+        SimpleTask.__init__(self, 'CheckBan')
+
+    def process(self, item):
+        msg = None
+        httpclient.AsyncHTTPClient.configure(None, defaults=dict(user_agent=USER_AGENT))
+        http_client = httpclient.HTTPClient()
+        try:
+            response = http_client.fetch("https://yourshot.nationalgeographic.com/static/img/navbar/yourshot-logo.svg") # static asset
+            # response = http_client.fetch("https://yourshot.nationalgeographic.com/api/v3/photos/search/")  # dynamic
+        except httpclient.HTTPError as e:
+            msg = "Failed to get CheckBan URL: " + str(e)
+            item.log_output(msg)
+            item.log_output("Sleeping 60...")
+            time.sleep(60)
+        http_client.close()
+        if msg != None:
+            raise Exception(msg)
+
 
 class PrepareDirectories(SimpleTask):
     def __init__(self, warc_prefix):
@@ -239,6 +259,7 @@ project = Project(
 
 pipeline = Pipeline(
     CheckIP(),
+    CheckBan(),
     GetItemFromTracker('http://%s/%s' % (TRACKER_HOST, TRACKER_ID), downloader,
         VERSION),
     PrepareDirectories(warc_prefix='yourshot'),

--- a/pipeline.py
+++ b/pipeline.py
@@ -64,7 +64,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20191014.02'
+VERSION = '20191014.03'
 USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'yourshot'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/pipeline.py
+++ b/pipeline.py
@@ -265,7 +265,7 @@ pipeline = Pipeline(
     PrepareDirectories(warc_prefix='yourshot'),
     WgetDownload(
         WgetArgs(),
-        max_tries=2,
+        max_tries=1,
         accept_on_exit_code=[0, 4, 8],
         env={
             'item_dir': ItemValue('item_dir'),

--- a/yourshot.lua
+++ b/yourshot.lua
@@ -221,6 +221,11 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     downloaded[string.gsub(url["url"], "https?://", "http://")] = true
   end
 
+  if status_code == 403 then
+    io.stdout:write("Your IP has gotten temporarily banned, try reducing --concurrency per IP after 10mins...\n")
+    abortgrab = true
+  end
+
   if abortgrab == true then
     io.stdout:write("ABORTING...\n")
     return wget.actions.ABORT

--- a/yourshot.lua
+++ b/yourshot.lua
@@ -252,11 +252,6 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     downloaded[string.gsub(url["url"], "https?://", "http://")] = true
   end
 
-  if status_code == 403 then
-    io.stdout:write("Your IP has gotten temporarily banned, try reducing --concurrency per IP after 10mins...\n")
-    abortgrab = true
-  end
-
   if abortgrab == true then
     io.stdout:write("ABORTING...\n")
     return wget.actions.ABORT


### PR DESCRIPTION
Your Shot servers will 403 for 15mins if some kind of rate limit is triggered.
This will help prevent the tracker's job pool being drained in such a scenario.

ToDo: detect and handle 403 in lua script as well.