### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 yourshot-grab
 =============
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Your Shot](http://archiveteam.org/index.php?title=Your Shot)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Your Shot](http://archiveteam.org/index.php?title=Your%20Shot)
 
 Setup instructions
 =========================


### PR DESCRIPTION
Apparently GitHub's markdown renderer doesn't like spaces in links:
![firefox_2019-10-20_12-11-38](https://user-images.githubusercontent.com/22377202/67157986-db9e2680-f332-11e9-9d12-7a6a59b9ce37.png)

This PR URL encodes the space, so the link is displayed correctly.